### PR TITLE
Fix the `java.lang.SecurityException` crash on Android 15 when starting a foreground service by specifying the foreground service type as `ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE`.

### DIFF
--- a/app/src/main/java/own/moderpach/extinguish/service/ExtinguishService.kt
+++ b/app/src/main/java/own/moderpach/extinguish/service/ExtinguishService.kt
@@ -7,7 +7,9 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.ServiceConnection
 import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
 import android.os.Binder
+import android.os.Build
 import android.os.IBinder
 import android.provider.Settings
 import android.util.Log
@@ -455,7 +457,12 @@ class ExtinguishService : LifecycleService() {
                             floatingButtonHost?.isShowing ?: false,
                             feature.enabledFloatingButtonControl
                         ).also {
-                            startForeground(NotificationHost.NOTIFICATION_ID, it)
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                                // Fix the crash at android 15, java.lang.SecurityException: Starting FGS with type specialUse callerApp=ProcessRecord{7536cde 20348:own.moderpach.extinguish/u0a616} targetSDK=35 requires permissions: all of the permissions allOf=true [android.permission.FOREGROUND_SERVICE_SPECIAL_USE]
+                                startForeground(NotificationHost.NOTIFICATION_ID, it, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+                            } else {
+                                startForeground(NotificationHost.NOTIFICATION_ID, it)
+                            }
                         }
 
                         state.update { State.Prepared }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.2.0"
+agp = "8.5.2"
 kotlin = "2.0.10"
 core-ktx = "1.13.1"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Dec 02 21:46:42 CST 2023
+#Sat Oct 04 18:07:36 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fix the `java.lang.SecurityException` crash on Android 15 when starting a foreground service by specifying the foreground service type as `ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE`. The corresponding exception stacktrace is shown below:

```java
Process: own.moderpach.extinguish, PID: 8465
  java.lang.SecurityException: Starting FGS with type specialUse callerApp=ProcessRecord{6cc5801 8465:own.moderpach.extinguish/u0a616} targetSDK=35 requires permissions: all of the permissions allOf=true [android.permission.FOREGROUND_SERVICE_SPECIAL_USE] 
   at android.os.Parcel.createExceptionOrNull(Parcel.java:3362)
   at android.os.Parcel.createException(Parcel.java:3346)
   at android.os.Parcel.readException(Parcel.java:3329)
   at android.os.Parcel.readException(Parcel.java:3271)
   at android.app.IActivityManager$Stub$Proxy.setServiceForeground(IActivityManager.java:7704)
   at android.app.Service.startForeground(Service.java:863)
   at own.moderpach.extinguish.service.ExtinguishService$initialize$1$7.invokeSuspend(ExtinguishService.kt:462)
   at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
   at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:231)
   at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:164)
   at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:466)
   at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:500)
   at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default(CancellableContinuationImpl.kt:489)
   at kotlinx.coroutines.CancellableContinuationImpl.resumeUndispatched(CancellableContinuationImpl.kt:587)
   at kotlinx.coroutines.android.HandlerContext$scheduleResumeAfterDelay$$inlined$Runnable$1.run(Runnable.kt:15)
   at android.os.Handler.handleCallback(Handler.java:995)
   at android.os.Handler.dispatchMessage(Handler.java:103)
   at android.os.Looper.loopOnce(Looper.java:265)
   at android.os.Looper.loop(Looper.java:358)
   at android.app.ActivityThread.main(ActivityThread.java:10061)
   at java.lang.reflect.Method.invoke(Native Method)
   at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:616)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1113)
```

[build] upgrade gradle to 8.7

Upgrade gradle to 8.7 and AGP to 8.5.2.